### PR TITLE
new HTMLBars.SafeString() --> String.htmlSafe()

### DIFF
--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -3,12 +3,9 @@ import Ember from 'ember';
 const {
   computed,
   Mixin,
-  Handlebars
+  Handlebars,
+  String: { htmlSafe }
 } = Ember;
-
-const {
-  SafeString
-} = Handlebars;
 
 export default Mixin.create({
   attributeBindings: ['touchActionStyle:style'],
@@ -32,6 +29,6 @@ export default Mixin.create({
       applyStyle = isFocusable;
     }
 
-    return new SafeString(applyStyle ? 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;' : '');
+    return new htmlSafe(applyStyle ? 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;' : '');
   })
 });


### PR DESCRIPTION
To address deprecation starting in Ember 2.6 - http://emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring