### PR TITLE
remove select from touch-action isFocusable list

### DIFF
--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -18,7 +18,7 @@ export default Mixin.create({
       const tagName = this.get('tagName');
       const type = this.get('type');
 
-      let isFocusable = ['select', 'button', 'input', 'a', 'textarea'].indexOf(tagName) !== -1;
+      let isFocusable = ['button', 'input', 'a', 'textarea'].indexOf(tagName) !== -1;
 
       if (isFocusable) {
         if (tagName === 'input') {

--- a/htmlbars-plugins/touch-action.js
+++ b/htmlbars-plugins/touch-action.js
@@ -53,7 +53,7 @@ TouchActionSupport.prototype.validate = function TouchActionSupport_validate(nod
     onValue = modifier ? hashPairForKey(modifier.hash, 'on') : false;
 
     hasAction = modifier && (!onValue || onValue === 'click');
-    isFocusable = ['select', 'button', 'input', 'a', 'textarea'].indexOf(node.tag) !== -1;
+    isFocusable = ['button', 'input', 'a', 'textarea'].indexOf(node.tag) !== -1;
 
     if (isFocusable) {
       if (node.tag === 'input') {


### PR DESCRIPTION
Native select menus do not trigger on android stock browsers even with hammer-time polyfill

As in https://github.com/runspired/ember-hammertime/issues/11 