### PR TITLE
Expose configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ partial handling of touch-action, but is also recommended CSS for all mobile bro
 
 The AST Walker automatically adds this style to elements when any of the following rules is matched.
 
-- The element's tagName is `select`, `button`, `a`, or `textarea`.
+- The element's tagName is `button`, `a`, or `textarea`.
 - The element's tagName is `input` and the element's `type` is `button`, `submit`, `text`, or `file`. 
 - The element has an action defined on it (e.g. `<div {{action "foo"}}>`)
 
@@ -65,6 +65,33 @@ It is heavily recommended to add the following rule to your site's CSS
   cursor: pointer;
 }
 ```
+
+### Configuration
+
+The AST Walker can be configured via config/environment.js:
+
+```javascript
+var ENV = {
+  // ...
+  EmberHammertime: {
+    touchActionSelectors: ['button', 'input', 'a', 'textarea'],
+    touchActionProperties: 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;'
+  }
+}
+```
+
+The same properties can be overridden on the touchAction Mixin or on your components directly.
+
+##### `touchActionSelectors`
+
+Defines which elements touch-action is applied to.
+Defaults to `['button', 'input', 'a', 'textarea']`
+
+##### `touchActionProperties`
+
+Defines the touch-action CSS style to be applied to the above selectors and `link-components`.
+Defaults to `'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;'`
+
 
 
 ## Contributing

--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -7,6 +7,9 @@ const {
 } = Ember;
 
 export default Mixin.create({
+  touchActionSelectors: ['button', 'input', 'a', 'textarea'],
+  touchActionProperties: 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;',
+
   init() {
     this._super(...arguments);
     if (this.tagName) {
@@ -17,7 +20,7 @@ export default Mixin.create({
     }
   },
 
-  touchActionStyle: computed(function() {
+  touchActionStyle: computed('touchActionSelectors', 'touchActionProperties', function() {
     // we apply if click is present and tagName is present
     let applyStyle = this.applyStyle && this.click;
 
@@ -26,7 +29,7 @@ export default Mixin.create({
       const tagName = this.get('tagName');
       const type = this.get('type');
 
-      let isFocusable = ['button', 'input', 'a', 'textarea'].indexOf(tagName) !== -1;
+      let isFocusable = this.get('touchActionSelectors').indexOf(tagName) !== -1;
 
       if (isFocusable) {
         if (tagName === 'input') {
@@ -37,6 +40,6 @@ export default Mixin.create({
       applyStyle = isFocusable;
     }
 
-    return htmlSafe(applyStyle ? 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;' : '');
+    return htmlSafe(applyStyle ? this.get('touchActionProperties') : '');
   })
 });

--- a/htmlbars-plugins/touch-action.js
+++ b/htmlbars-plugins/touch-action.js
@@ -11,63 +11,68 @@
  <HTMLElement {{action "foo"}} style="touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;">
  ```
  */
-var TOUCH_ACTION = 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;';
 
-function TouchActionSupport() {
-  this.syntax = null;
+function TouchAction(config) {
+  var touchActionSelectors = ['button', 'input', 'a', 'textarea'];
+  var touchActionProperties = 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;';
+  config = config || {};
+
+  var TouchActionSupport = function TouchActionSupport() {
+    this.touchActionSelectors = config.touchActionSelectors || touchActionSelectors;
+    this.touchActionProperties = config.touchActionProperties || touchActionProperties;
+    this.syntax = null;
+  };
+
+  TouchActionSupport.prototype.transform = function TouchActionSupport_transform(ast) {
+    var pluginContext = this;
+    var walker = new pluginContext.syntax.Walker();
+
+    walker.visit(ast, function(node) {
+      if (pluginContext.validate(node)) {
+        var style = elementAttribute(node, 'style');
+        if (!style) {
+          style = {
+            type: 'AttrNode',
+            name: 'style',
+            value: { type: 'TextNode', chars: '' }
+          };
+          node.attributes.push(style);
+        }
+        style.value.chars += pluginContext.touchActionProperties;
+      }
+    });
+
+    return ast;
+  };
+
+  TouchActionSupport.prototype.validate = function TouchActionSupport_validate(node) {
+    var modifier;
+    var onValue;
+    var hasAction;
+    var isFocusable;
+
+    if (node.type === 'ElementNode') {
+      modifier = elementModifierForPath(node, 'action');
+      onValue = modifier ? hashPairForKey(modifier.hash, 'on') : false;
+
+      hasAction = modifier && (!onValue || onValue === 'click');
+      isFocusable = this.touchActionSelectors.indexOf(node.tag) !== -1;
+
+      if (isFocusable) {
+        if (node.tag === 'input') {
+          var type = elementAttribute(node, 'type');
+          isFocusable = ['button', 'submit', 'text', 'file'].indexOf(type) !== -1;
+        }
+      }
+
+      return hasAction || isFocusable;
+    }
+
+    return false;
+  };
+
+  return TouchActionSupport;
 }
-
-
-TouchActionSupport.prototype.transform = function TouchActionSupport_transform(ast) {
-  var pluginContext = this;
-  var walker = new pluginContext.syntax.Walker();
-
-  walker.visit(ast, function(node) {
-    if (pluginContext.validate(node)) {
-      var style = elementAttribute(node, 'style');
-      if (!style) {
-        style = {
-          type: 'AttrNode',
-          name: 'style',
-          value: { type: 'TextNode', chars: '' }
-        };
-        node.attributes.push(style);
-      }
-      style.value.chars += TOUCH_ACTION;
-    }
-  });
-
-  return ast;
-
-
-};
-
-TouchActionSupport.prototype.validate = function TouchActionSupport_validate(node) {
-  var modifier;
-  var onValue;
-  var hasAction;
-  var isFocusable;
-
-  if (node.type === 'ElementNode') {
-    modifier = elementModifierForPath(node, 'action');
-    onValue = modifier ? hashPairForKey(modifier.hash, 'on') : false;
-
-    hasAction = modifier && (!onValue || onValue === 'click');
-    isFocusable = ['button', 'input', 'a', 'textarea'].indexOf(node.tag) !== -1;
-
-    if (isFocusable) {
-      if (node.tag === 'input') {
-        var type = elementAttribute(node, 'type');
-        isFocusable = ['button', 'submit', 'text', 'file'].indexOf(type) !== -1;
-      }
-    }
-
-    return hasAction || isFocusable;
-  }
-
-  return false;
-};
-
 
 function elementAttribute(node, path) {
   var attributes = node.attributes;
@@ -114,4 +119,4 @@ function sexpr(node) {
 }
 
 
-module.exports = TouchActionSupport;
+module.exports = TouchAction;

--- a/index.js
+++ b/index.js
@@ -26,12 +26,17 @@ module.exports = {
     return false;
   },
 
+  projectConfig: function () {
+    return this.project.config(process.env.EMBER_ENV);
+  },
+
   setupPreprocessorRegistry: function(type, registry) {
     var TouchAction = require('./htmlbars-plugins/touch-action');
+    var config = this.projectConfig()['EmberHammertime'];
 
     registry.add('htmlbars-ast-plugin', {
       name: "touch-action",
-      plugin: TouchAction,
+      plugin: new TouchAction(config),
       baseDir: function() {
         return __dirname;
       }


### PR DESCRIPTION
##### `touchActionSelectors`
  - Defines which elements touch-action is applied to
  - Defaults to `['button', 'input', 'a', 'textarea']`

##### `touchActionProperties`
  -  Defines the touch-action CSS style to be applied
  - Defaults to `'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;'`

Config for AST walkers is defined in config/environment.js in an `EmberHammertime` object

Ember Components can override `touchActionSelectors` or `touchActionProperties` on the component or mixin directly