### PR TITLE
Provide baseDir to allow for proper caching

### DIFF
--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -3,7 +3,6 @@ import Ember from 'ember';
 const {
   computed,
   Mixin,
-  Handlebars,
   String: { htmlSafe }
 } = Ember;
 
@@ -29,6 +28,6 @@ export default Mixin.create({
       applyStyle = isFocusable;
     }
 
-    return new htmlSafe(applyStyle ? 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;' : '');
+    return htmlSafe(applyStyle ? 'touch-action: manipulation; -ms-touch-action: manipulation; cursor: pointer;' : '');
   })
 });

--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ module.exports = {
 
     registry.add('htmlbars-ast-plugin', {
       name: "touch-action",
-      plugin: TouchAction
+      plugin: TouchAction,
+      baseDir: function() {
+        return __dirname;
+      }
     });
 
   }


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli-htmlbars/pull/90 – there is a deprecation warning with Ember 2.7:
```
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `touch-action`
```

Also clean up jshint warnings:
```
modules/ember-hammertime/mixins/touch-action.js: line 32, col 16, A constructor name should start with an uppercase letter.
modules/ember-hammertime/mixins/touch-action.js: line 6, col 3, 'Handlebars' is defined but never used.
```

