### PR TITLE
Fix Error: `cannot use `attributeBindings` on a tag-less component`

### DIFF
--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -7,10 +7,19 @@ const {
 } = Ember;
 
 export default Mixin.create({
-  attributeBindings: ['touchActionStyle:style'],
+  init() {
+    this._super(...arguments);
+    if (this.tagName) {
+      this.attributeBindings = ['touchActionStyle:style'];
+      this.applyStyle = true;
+    } else {
+      this.applyStyle = false;
+    }
+  },
+
   touchActionStyle: computed(function() {
-    // we apply if click is present
-    let applyStyle = this.click;
+    // we apply if click is present and tagName is present
+    let applyStyle = this.applyStyle && this.click;
 
     if (!applyStyle) {
       // we apply if tagName


### PR DESCRIPTION
Modify touch-action mixin to smartly add `attributeBindings` to prevent
assertion error from being thrown in ember beta/canary.

Error is thrown when using 2.8.0-beta.3+cf714821 and 2.9.0-master+3f4ba8d4