### PR TITLE
fix error thrown when tagName has not yet been defined on a component

### DIFF
--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -45,8 +45,12 @@ export default Mixin.create({
       click
     } = this;
 
-    let maybeApplyStyle = ignoreTouchAction === false && tagName !== '';
-    let hasClickHandler = ignoreTouchAction === false && click !== K;
+    const hasClick = click !== K;
+    const hasTag = (typeof tagName === 'string' && tagName.length > 0) || (tagName === null && hasClick);
+    if (!hasTag) { return; }
+
+    let maybeApplyStyle = ignoreTouchAction === false && hasTag;
+    let hasClickHandler = ignoreTouchAction === false && hasClick;
     let shouldApplyStyle = false;
 
     if (maybeApplyStyle) {

--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -49,7 +49,7 @@ export default Mixin.create({
     const hasTag = (typeof tagName === 'string' && tagName.length > 0) || (tagName === null && hasClick);
     if (!hasTag) { return; }
 
-    let maybeApplyStyle = ignoreTouchAction === false && hasTag;
+    let maybeApplyStyle = ignoreTouchAction === false;
     let hasClickHandler = ignoreTouchAction === false && hasClick;
     let shouldApplyStyle = false;
 


### PR DESCRIPTION
- has to do with with glimmer2 component instantiation differing from
  glimmer1 (even without glimmer flag enabled)
- affects concatenated properties and apply mixin logic in ember metal
- source of actual difference in code paths unknown ATM

fixes #19 
