### PR TITLE
Dont use Ember.K to check for typeof function check

### DIFF
--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -3,7 +3,6 @@ import Ember from "ember";
 const {
   computed,
   defineProperty,
-  K,
   get,
   Mixin,
   String: {htmlSafe, isHTMLSafe}
@@ -37,7 +36,7 @@ export default Mixin.create({
   ignoreTouchAction: false,
 
   init() {
-    this._super();
+    this._super(...arguments);
 
     const {
       tagName,
@@ -45,7 +44,7 @@ export default Mixin.create({
       click
     } = this;
 
-    const hasClick = click !== K;
+    const hasClick = typeof click === 'function';
     const hasTag = (typeof tagName === 'string' && tagName.length > 0) || (tagName === null && hasClick);
     if (!hasTag) { return; }
 

--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -44,8 +44,8 @@ export default Mixin.create({
       click
     } = this;
 
-    const hasClick = typeof click === 'function';
-    const hasTag = (typeof tagName === 'string' && tagName.length > 0) || (tagName === null && hasClick);
+    const hasClick = click && click.apply;
+    const hasTag = tagName !== '' || (tagName === null && hasClick);
     if (!hasTag) { return; }
 
     let maybeApplyStyle = ignoreTouchAction === false;

--- a/addon/mixins/touch-action.js
+++ b/addon/mixins/touch-action.js
@@ -36,7 +36,7 @@ export default Mixin.create({
   ignoreTouchAction: false,
 
   init() {
-    this._super(...arguments);
+    this._super();
 
     const {
       tagName,


### PR DESCRIPTION
fixes issue whereby every ``{{some-component}}`` was being given the touch action style tag

K