### PR TITLE
allow disabling via config

### DIFF
--- a/htmlbars-plugins/touch-action.js
+++ b/htmlbars-plugins/touch-action.js
@@ -146,7 +146,7 @@ function sexpr(node) {
 function setConfigValues(config) {
   config = config || {};
 
-  touchActionOnAction = config.touchActionOnAction || touchActionOnAction;
+  touchActionOnAction = typeof config.touchActionOnAction === 'undefined' ? touchActionOnAction : config.touchActionOnAction;
   touchActionAttributes = config.touchActionAttributes || touchActionAttributes;
   touchActionSelectors = config.touchActionSelectors || touchActionSelectors;
   touchActionProperties = config.touchActionProperties || touchActionProperties;


### PR DESCRIPTION
Currently it's not possible to disable addon using app config:
`touchActionOnAction = config.touchActionOnAction || touchActionOnAction;` <- this line will always be true, because `touchActionOnAction = true` 